### PR TITLE
Store current profile per character+realm

### DIFF
--- a/RABuffs_ui.lua
+++ b/RABuffs_ui.lua
@@ -59,7 +59,7 @@ StaticPopupDialogs["RAB_PROFILE_CREATE_PROMPT"] = {
         local profileName = getglobal(this:GetParent():GetName().."EditBox"):GetText();
         if profileName and profileName ~= "" then
             if RAB_CreateNewProfile(profileName) then
-                RABui_Settings.currentProfile = profileName;
+                RAB_SetCurrentProfile(profileName);
                 if RABui_UpdateTitle then
                     RABui_UpdateTitle();
                 end
@@ -73,7 +73,7 @@ StaticPopupDialogs["RAB_PROFILE_CREATE_PROMPT"] = {
         local profileName = this:GetText();
         if profileName and profileName ~= "" then
             if RAB_CreateNewProfile(profileName) then
-                RABui_Settings.currentProfile = profileName;
+                RAB_SetCurrentProfile(profileName);
                 if RABui_UpdateTitle then
                     RABui_UpdateTitle();
                 end
@@ -102,7 +102,7 @@ StaticPopupDialogs["RAB_PROFILE_SAVE_PROMPT"] = {
         local profileName = getglobal(this:GetParent():GetName().."EditBox"):GetText();
         if profileName and profileName ~= "" then
             if RAB_SaveProfile(profileName) then
-                RABui_Settings.currentProfile = profileName;
+                RAB_SetCurrentProfile(profileName);
                 if RAB_Settings_ProfileSelector_UpdateText then
                     RAB_Settings_ProfileSelector_UpdateText();
                 end
@@ -115,7 +115,7 @@ StaticPopupDialogs["RAB_PROFILE_SAVE_PROMPT"] = {
         local profileName = this:GetText();
         if profileName and profileName ~= "" then
             if RAB_SaveProfile(profileName) then
-                RABui_Settings.currentProfile = profileName;
+                RAB_SetCurrentProfile(profileName);
                 if RAB_Settings_ProfileSelector_UpdateText then
                     RAB_Settings_ProfileSelector_UpdateText();
                 end
@@ -220,7 +220,7 @@ StaticPopupDialogs["RAB_PROFILE_IMPORT_NAME"] = {
             else
                 -- Profile doesn't exist, import directly
                 if RAB_ImportProfile(profileName, RAB_ImportProfileData) then
-                    RABui_Settings.currentProfile = profileName;
+                    RAB_SetCurrentProfile(profileName);
                     RAB_LoadProfile(profileName);
                     if RAB_Settings_ProfileSelector_UpdateText then
                         RAB_Settings_ProfileSelector_UpdateText();
@@ -240,7 +240,7 @@ StaticPopupDialogs["RAB_PROFILE_IMPORT_NAME"] = {
                 this:GetParent():Hide();
             else
                 if RAB_ImportProfile(profileName, RAB_ImportProfileData) then
-                    RABui_Settings.currentProfile = profileName;
+                    RAB_SetCurrentProfile(profileName);
                     RAB_LoadProfile(profileName);
                     if RAB_Settings_ProfileSelector_UpdateText then
                         RAB_Settings_ProfileSelector_UpdateText();
@@ -268,7 +268,7 @@ StaticPopupDialogs["RAB_PROFILE_IMPORT_CONFIRM"] = {
     OnAccept = function()
         if RAB_ProfileToImport and RAB_ImportProfileData then
             if RAB_ImportProfile(RAB_ProfileToImport, RAB_ImportProfileData) then
-                RABui_Settings.currentProfile = RAB_ProfileToImport;
+                RAB_SetCurrentProfile(RAB_ProfileToImport);
                 RAB_LoadProfile(RAB_ProfileToImport);
                 if RAB_Settings_ProfileSelector_UpdateText then
                     RAB_Settings_ProfileSelector_UpdateText();
@@ -521,7 +521,7 @@ SlashCmdList["RABUFFS"] = function(msg)
             
             if (subcmd == "list") then
                 local profiles = RAB_GetAllProfiles();
-                local current = RABui_Settings.currentProfile or "Default";
+                local current = RAB_GetCurrentProfile();
                 RAB_Print("Available profiles:");
                 for i, profile in ipairs(profiles) do
                     local marker = (profile == current) and " (current)" or "";
@@ -531,7 +531,7 @@ SlashCmdList["RABUFFS"] = function(msg)
                     RAB_Print("  Default (current)");
                 end
             elseif (subcmd == "current") then
-                local current = RABui_Settings.currentProfile or "Default";
+                local current = RAB_GetCurrentProfile();
                 RAB_Print("Current profile: " .. current);
             elseif (subcmd == "save" and profileName) then
                 RAB_SaveProfile(profileName);

--- a/RABuffs_vui.lua
+++ b/RABuffs_vui.lua
@@ -298,7 +298,7 @@ function RABui_Menu_Initialize()
 	});
 	UIDropDownMenu_AddButton({ text = "", disabled = 1, notCheckable = 1 });
 	UIDropDownMenu_AddButton({
-		text = "Current Profile: " .. (RABui_Settings.currentProfile or "Default"),
+		text = "Current Profile: " .. (RAB_GetCurrentProfile()),
 		isTitle = 1
 	});
 	UIDropDownMenu_AddButton({
@@ -335,7 +335,7 @@ function RABui_Menu_Initialize()
 
 	-- Add delete current profile option
 	local profiles = RAB_GetAllProfiles();
-	local current = RABui_Settings.currentProfile or "Default";
+	local current = RAB_GetCurrentProfile();
 	local profileCount = table.getn(profiles);
 
 	-- Add default if not in list for counting
@@ -364,7 +364,7 @@ function RABui_Menu_Initialize()
 
 	-- Add profile load options directly
 	profiles = RAB_GetAllProfiles();
-	current = RABui_Settings.currentProfile or "Default";
+	current = RAB_GetCurrentProfile();
 
 	-- Always include Default
 	local hasDefault = false;
@@ -1482,7 +1482,7 @@ function RABui_BarDetail_RemoveBar()
 end
 
 function RABui_Settings_Layout_ClearAllBars()
-	local currentProfile = RABui_Settings.currentProfile or "Default";
+	local currentProfile = RAB_GetCurrentProfile();
 	StaticPopup_Show("RAB_CLEAR_ALL_BARS_CONFIRM", currentProfile);
 end
 
@@ -1553,7 +1553,7 @@ function RABui_Settings_localizationSelector_UpdateText()
 end
 
 function RABui_UpdateTitle()
-	local currentProfile = RABui_Settings.currentProfile or "Default";
+	local currentProfile = RAB_GetCurrentProfile();
 	RAB_Title:SetText(sRAB_Settings_UIHeader .. ": " .. currentProfile .. "");
 end
 


### PR DESCRIPTION
Store the last used profile per character+realm instead of globally.

The current method of storing just the last used profile in one place means switching between characters can pick a shaman healing profile for your tanking warrior etc